### PR TITLE
Read all contents of a given google sheet without having to specify a…

### DIFF
--- a/src/endlib.js
+++ b/src/endlib.js
@@ -348,7 +348,7 @@ window.count = 0;
 
 window.getApiUrl = function(tabName) {
     tabName = tabName.replace(/\//, '-');
-    return `https://sheets.googleapis.com/v4/spreadsheets/1QIcvf5S0IrTJ2GD8DcTtIW-UxAGh5oF6Hm7Rvuq8Wms/values/${tabName}!A1:G5000?key=AIzaSyD2GEqV6DLpVO-RyVufOloqfUWjzNMHSgA`;
+    return `https://sheets.googleapis.com/v4/spreadsheets/1QIcvf5S0IrTJ2GD8DcTtIW-UxAGh5oF6Hm7Rvuq8Wms/values/${tabName}?key=AIzaSyD2GEqV6DLpVO-RyVufOloqfUWjzNMHSgA`;
 }
 
 // age group tab name to Standards arr


### PR DESCRIPTION
Remove hardcoded cell range to allow reading the entire contents of a google sheet. Here's the API examples: https://developers.google.com/sheets/api/guides/concepts#expandable-1 

Tested in a few different ways:
1. Built local instance to see to it that this doesn't break anything.
2. Intentionally broke the code to confirm that my changes were being reflected. 
3. Lastly, spot checked against the google data sheet to see to it that the latest 1 or 2 data point(s) from 'Endurance' tab do show up in the local instance.
<img width="1218" alt="Screenshot 2024-12-03 at 12 22 01 PM" src="https://github.com/user-attachments/assets/3c2fa94c-d4b2-449a-a6da-e3e3fb1cdd61">
<img width="905" alt="Screenshot 2024-12-03 at 12 25 00 PM" src="https://github.com/user-attachments/assets/f4102489-4849-4f62-a801-340c5e6eba95">
<img width="808" alt="Screenshot 2024-12-03 at 12 25 15 PM" src="https://github.com/user-attachments/assets/d267126f-6238-4fa8-9161-d7ca12208255">
 